### PR TITLE
feat: log Ollama token usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -461,6 +461,8 @@ rag = LightRAG(
 )
 ```
 
+When used with the `TokenTracker`, Ollama calls now report prompt, completion, and total token usage automatically, similar to the OpenAI and WatsonX integrations.
+
 * **Increasing context size**
 
 In order for LightRAG to work context should be at least 32k tokens. By default Ollama models have context size of 8k. You can achieve this using one of two ways:


### PR DESCRIPTION
## Summary
- track token usage for Ollama completions, including streaming responses
- document TokenTracker support for Ollama models

## Testing
- `pre-commit run --files README.md lightrag/llm/ollama.py`


------
https://chatgpt.com/codex/tasks/task_e_689c7ba3f3f4832f85713fd050a87af8